### PR TITLE
For Continuity, Remove "www." from massdrop.com

### DIFF
--- a/safeWebsiteList.txt
+++ b/safeWebsiteList.txt
@@ -5,4 +5,4 @@ reddit.com
 youtube.com
 amazon.com
 amazon.co.uk
-www.massdrop.com
+massdrop.com


### PR DESCRIPTION
All other websites on the list do not have www.
In safeWebsiteList.txt:
-remove the www. from massdrop.com.